### PR TITLE
Add generation of .pfx archives for client certificates

### DIFF
--- a/tls/client-only/README.md
+++ b/tls/client-only/README.md
@@ -36,7 +36,7 @@ hash --> will automatically follow the guidelines in RFC3280</br>
 [source][1]
 
 ### Notes
-- The generated certificates are in PKCS12 format
+- The generated certificates are in PKCS8 and PKCS12 format
 - The generated certificates are hard-coded as valid for 365 days
 - This requires two separate scripts to run to make it possible to both create a variable number of end-entity certificates at any point in time. 
 - These certificates should be used only to inform that a connection can be made, and is not to be used in production. 

--- a/tls/client-only/README.md
+++ b/tls/client-only/README.md
@@ -4,8 +4,8 @@ These scripts generate only the client-side certificates, along with their keys 
 
 ### User Instructions 
 
-2. To generate the root certificate run the `ca.sh` script.
-3. To generate an end-entity certificate, run the `end-entity` script.
+1. To generate the root certificate run the `ca.sh` script.
+2. To generate an end-entity certificate, run the `end-entity` script. `end-entity` script requires `ca.sh` to be run first because it reuses it's input.
 
 ### Additional Documentation 
 
@@ -36,6 +36,7 @@ hash --> will automatically follow the guidelines in RFC3280</br>
 [source][1]
 
 ### Notes
+- The generated certificates are in PKCS12 format
 - The generated certificates are hard-coded as valid for 365 days
 - This requires two separate scripts to run to make it possible to both create a variable number of end-entity certificates at any point in time. 
 - These certificates should be used only to inform that a connection can be made, and is not to be used in production. 

--- a/tls/client-only/mac/end-entity.sh
+++ b/tls/client-only/mac/end-entity.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-echo "Enter a unique name for the prefix of the .pem and .key files":
+
+test ! -e ca.conf && echo "ca.sh has to be run before" && exit 1
+
+echo "Enter a unique name for the prefix of the .pem, .key, and .pfx files":
 read UNIQUE_NAME
 echo "Generating private key and CSR"
 
@@ -37,17 +40,21 @@ DNS.1 = $DNS_END_ENTITY
 EOF
 
 # Generate client's private key and certificate signing request (CSR)
-openssl req -newkey rsa:4096 -nodes -keyout "${UNIQUE_NAME}.key" -out "${UNIQUE_NAME}-req.pem" -config "${UNIQUE_NAME}.conf"
+openssl req -newkey rsa:4096 -nodes -keyout "${UNIQUE_NAME}.key" -out "${UNIQUE_NAME}-req.csr" -config "${UNIQUE_NAME}.conf"
 
 echo "Signing certificate"
 
 # Use CA's private key to sign client's CSR and get back the signed certificate
-openssl x509 -days 365 -req -in "${UNIQUE_NAME}-req.pem" -CA "ca.pem" -CAkey "ca.key" -CAcreateserial -out "${UNIQUE_NAME}.pem" -extfile "${UNIQUE_NAME}.conf"
+openssl x509 -days 365 -req -in "${UNIQUE_NAME}-req.csr" -CA "ca.pem" -CAkey "ca.key" -CAcreateserial -out "${UNIQUE_NAME}.pem" -extfile "${UNIQUE_NAME}.conf"
+
+echo "Exporting into an unencrypted .pfx archive"
+# "-keypbe NONE -certpbe NONE -passout pass:" exports into an unencrypted .pfx archive
+openssl pkcs12 -export -out ${UNIQUE_NAME}.pfx -inkey ${UNIQUE_NAME}.key -in ${UNIQUE_NAME}.pem -keypbe NONE -certpbe NONE -passout pass:
 
 # Delete the certificate signing request after the certificate has been signed. 
-rm "${UNIQUE_NAME}-req.pem"
+rm "${UNIQUE_NAME}-req.csr"
 
 echo "Printing signed end-entity certificate"
 openssl x509 -in "${UNIQUE_NAME}.pem" -noout -text
 
-echo "---> Keep these files secure, and use ${UNIQUE_NAME}.pem and ${UNIQUE_NAME}.key in the SDK"
+echo "---> Keep these files secure, and use ${UNIQUE_NAME}.pfx or ${UNIQUE_NAME}.pem and ${UNIQUE_NAME}.key in the SDK"

--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -1,6 +1,7 @@
 ### TLS
 This sample demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within a Temporal cluster when using intermediate CAs and different certificate chains for cluster and clients.
 It also shows how different clients can be given different server certificates when connecting to the same cluster using different server names.
+The generated certificates are in PKCS12 format.
 
 ### Steps to run this sample
 1. Generate test certificates with `generate-certs.sh`. This will create server and client certificates in a `certs` subdirectory.

--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -1,7 +1,7 @@
 ### TLS
 This sample demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within a Temporal cluster when using intermediate CAs and different certificate chains for cluster and clients.
 It also shows how different clients can be given different server certificates when connecting to the same cluster using different server names.
-The generated certificates are in PKCS12 format.
+The generated certificates are in PKCS1 and PKCS12 (client-only) format.
 
 ### Steps to run this sample
 1. Generate test certificates with `generate-certs.sh`. This will create server and client certificates in a `certs` subdirectory.

--- a/tls/tls-full/generate-certs.sh
+++ b/tls/tls-full/generate-certs.sh
@@ -31,6 +31,9 @@ generate_cert() {
     then
       cat $2/$1.pem $3.pem > $2/$1-chain.pem
     fi
+    # Export to .pfx
+    # "-keypbe NONE -certpbe NONE -passout pass:" exports into an unencrypted .pfx archive
+    openssl pkcs12 -export -out $2/$1.pfx -inkey $2/$1.key -in $2/$1.pem -keypbe NONE -certpbe NONE -passout pass:
 }
 
 echo Generate a private key and a certificate for server root CA

--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -1,6 +1,6 @@
 ### TLS
 This samples demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within Temporal cluster.
-The generated certificates are in PKCS12 format.
+The generated certificates are in PKCS1 and PKCS12 format.
 
 ### Steps to run this sample
 1. Generate test certificates with `generate-test-certs.sh`. This will create server and client certificates in the `certs` subdirectory.

--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -1,5 +1,6 @@
 ### TLS
 This samples demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within Temporal cluster.
+The generated certificates are in PKCS12 format.
 
 ### Steps to run this sample
 1. Generate test certificates with `generate-test-certs.sh`. This will create server and client certificates in the `certs` subdirectory.

--- a/tls/tls-simple/generate-test-certs.sh
+++ b/tls/tls-simple/generate-test-certs.sh
@@ -18,3 +18,6 @@ openssl x509 -req -in $CERTS_DIR/cluster.csr -CA $CERTS_DIR/ca.cert -CAkey $CERT
 openssl genrsa -out $CERTS_DIR/client.key 4096
 openssl req -new -key $CERTS_DIR/client.key -out $CERTS_DIR/client.csr -config client-cert.conf
 openssl x509 -req -in $CERTS_DIR/client.csr -CA $CERTS_DIR/ca.cert -CAkey $CERTS_DIR/ca.key -CAcreateserial -out $CERTS_DIR/client.pem -days 365 -sha256 -extfile client-cert.conf -extensions req_ext
+# Export to .pfx 
+# "-keypbe NONE -certpbe NONE -passout pass:" specifies an unencrypted archive
+openssl pkcs12 -export -out $CERTS_DIR/client.pfx -inkey $CERTS_DIR/client.key -in $CERTS_DIR/client.pem -keypbe NONE -certpbe NONE -passout pass:


### PR DESCRIPTION
## What was changed
This PR adds a step that exports all client-side certificates into .pfx  - standard PKCS12 distribution format. It should help users with bridging our TSL setup examples/documentation with JavaSDK. 
A clarification was added into javadocs about the format of the certificates generated by samples.

## Why?
https://github.com/temporalio/sdk-java/issues/925
There is a relevant change into JavaSDK that actually adds support for the PFX format. Previously users had to convert PKCS12 into PKCS8 just for JavaSDK: https://github.com/temporalio/sdk-java/pull/941

How was this tested:
Checked that all 3 samples still work and produce an output.