### PR TITLE
Fix TLS sample

### DIFF
--- a/tls/config/dynamicconfig/development.yaml
+++ b/tls/config/dynamicconfig/development.yaml
@@ -1,0 +1,31 @@
+#server:
+#  dynamicConfig:
+frontend.enableClientVersionCheck:
+- value: true
+  constraints: {}
+history.persistenceMaxQPS:
+- value: 3000
+  constraints: {}
+frontend.persistenceMaxQPS:
+- value: 3000
+  constraints: {}
+frontend.throttledLogRPS:
+- value: 20
+  constraints: {}
+history.defaultActivityRetryPolicy:
+- value:
+    InitialIntervalInSeconds: 1
+    MaximumIntervalCoefficient: 100.0
+    BackoffCoefficient: 2.0
+    MaximumAttempts: 0
+history.defaultWorkflowRetryPolicy:
+- value:
+    InitialIntervalInSeconds: 1
+    MaximumIntervalCoefficient: 100.0
+    BackoffCoefficient: 2.0
+    MaximumAttempts: 0
+system.advancedVisibilityWritingMode:
+  - value: "off"
+    constraints: {}
+#system.enableParentClosePolicyWorker:
+#  - value: true

--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -14,5 +14,6 @@ bash generate-certs.sh
 2. Start Temporal with `start-temporal.sh`. This will bring up a Temporal cluster (via `docker-compose`) with the `certs` subdirectory mounted as a volume and Temporal configured to use the test certificates in it to secure network communications.
 
 ```bash
-SERVER_TAG=1.12.4 && bash start-temporal.sh
+bash start-temporal.sh
 ```
+

--- a/tls/tls-full/config_template.yaml
+++ b/tls/tls-full/config_template.yaml
@@ -123,7 +123,6 @@ global:
                 requireClientAuth: true
                 certFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.pem
                 keyFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.key
-                requireClientAuth: true
                 clientCaFiles:
                     - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
             client:

--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -13,5 +13,6 @@ bash generate-test-certs.sh
 2. Start Temporal with `start-temporal.sh`. This will bring up a Temporal cluster (via `docker-compose`) with the `certs` subdirectory mounted as a volume and Temporal configured to use the test certificates in it to secure network communications.
 
 ```bash
-SERVER_TAG=1.12.4 && bash start-temporal.sh
+bash start-temporal.sh
 ```
+


### PR DESCRIPTION
## What was changed
Added a copy of the standard dynamic config - development.yaml.
Removed duplicate `requireClientAuth` field from config.

## Why?
Fixed TLS samples, so that they work with the latest version of Temporal.
Removed hardcoded 1.12.4 version from readmes

## Checklist
2. How was this tested:
Manually

3. Any docs updates needed?
No
