### PR TITLE
Update client certificates in both tls-full and tsl-simple to PKCS8

### DIFF
--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -2,7 +2,9 @@
 
 This sample demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within a Temporal cluster when using intermediate CAs and different certificate chains for cluster and clients.
 It also shows how different clients can be given different server certificates when connecting to the same cluster using different server names.
-The generated certificates are in PKCS1 and PKCS12 (client-only) format.
+The generated certificates are in 
+  - PKCS1 format for server
+  - PKCS8 and PKCS12 format for client
 
 ### Steps to run this sample
 

--- a/tls/tls-full/generate-certs.sh
+++ b/tls/tls-full/generate-certs.sh
@@ -24,16 +24,19 @@ generate_root_ca_cert() {
 }
 
 generate_cert() {
-    openssl genrsa -out $2/$1.key 4096
-    openssl req -new -key $2/$1.key -out $TEMP_DIR/$1.csr -config $1.conf
+    openssl req -newkey rsa:4096 -nodes -keyout "$2/$1.key" -out "$TEMP_DIR/$1.csr" -config "$1.conf"
     openssl x509 -req -in $TEMP_DIR/$1.csr -CA $3.pem -CAkey $3.key -CAcreateserial -out $2/$1.pem -days 365 -extfile $1.conf -extensions $4
+    CHAIN_FILE="$2/$1.pem"
     if [[ $5 != 'no_chain' ]]
     then
       cat $2/$1.pem $3.pem > $2/$1-chain.pem
+      CHAIN_FILE="$2/$1-chain.pem"
     fi
-    # Export to .pfx
-    # "-keypbe NONE -certpbe NONE -passout pass:" exports into an unencrypted .pfx archive
-    openssl pkcs12 -export -out $2/$1.pfx -inkey $2/$1.key -in $2/$1.pem -keypbe NONE -certpbe NONE -passout pass:
+
+      # Export to .pfx
+      # "-keypbe NONE -certpbe NONE -passout pass:" exports into an unencrypted .pfx archive
+      openssl pkcs12 -export -out $2/$1.pfx -inkey $2/$1.key -in $CHAIN_FILE -keypbe NONE -certpbe NONE -passout pass:  
+
 }
 
 echo Generate a private key and a certificate for server root CA

--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -1,7 +1,9 @@
 ### TLS
 
 This samples demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within Temporal cluster.
-The generated certificates are in PKCS1 and PKCS12 format.
+The generated certificates are in 
+  - PKCS1 format for server
+  - PKCS8 and PKCS12 format for client
 
 ### Steps to run this sample
 

--- a/tls/tls-simple/generate-test-certs.sh
+++ b/tls/tls-simple/generate-test-certs.sh
@@ -15,8 +15,7 @@ openssl req -new -key $CERTS_DIR/cluster.key -out $CERTS_DIR/cluster.csr -config
 openssl x509 -req -in $CERTS_DIR/cluster.csr -CA $CERTS_DIR/ca.cert -CAkey $CERTS_DIR/ca.key -CAcreateserial -out $CERTS_DIR/cluster.pem -days 365 -sha256 -extfile cluster-cert.conf -extensions req_ext
 
 # Generate a private key and a certificate for clients
-openssl genrsa -out $CERTS_DIR/client.key 4096
-openssl req -new -key $CERTS_DIR/client.key -out $CERTS_DIR/client.csr -config client-cert.conf
+openssl req -newkey rsa:4096 -nodes -keyout "$CERTS_DIR/client.key" -out "$CERTS_DIR/client.csr" -config client-cert.conf
 openssl x509 -req -in $CERTS_DIR/client.csr -CA $CERTS_DIR/ca.cert -CAkey $CERTS_DIR/ca.key -CAcreateserial -out $CERTS_DIR/client.pem -days 365 -sha256 -extfile client-cert.conf -extensions req_ext
 # Export to .pfx 
 # "-keypbe NONE -certpbe NONE -passout pass:" specifies an unencrypted archive


### PR DESCRIPTION
Migrate tls-full and tsl-simple client certs generation to PKCS8
Per discussion in https://github.com/temporalio/samples-server/pull/21
