### PR TITLE
Add an explicit -sha256 flag

### DIFF
--- a/tls/tls-full/generate-certs.sh
+++ b/tls/tls-full/generate-certs.sh
@@ -20,12 +20,12 @@ mkdir $TEMP_DIR
 
 generate_root_ca_cert() {
     openssl genrsa -out $2/$1.key 4096
-    openssl req -new -x509 -key $2/$1.key -config $1.conf -days 365 -out $2/$1.pem
+    openssl req -new -x509 -key $2/$1.key -sha256 -config $1.conf -days 365 -out $2/$1.pem
 }
 
 generate_cert() {
-    openssl req -newkey rsa:4096 -nodes -keyout "$2/$1.key" -out "$TEMP_DIR/$1.csr" -config "$1.conf"
-    openssl x509 -req -in $TEMP_DIR/$1.csr -CA $3.pem -CAkey $3.key -CAcreateserial -out $2/$1.pem -days 365 -extfile $1.conf -extensions $4
+    openssl req -newkey rsa:4096 -nodes -keyout "$2/$1.key" -sha256 -out "$TEMP_DIR/$1.csr" -config "$1.conf"
+    openssl x509 -req -in $TEMP_DIR/$1.csr -CA $3.pem -CAkey $3.key -sha256 -CAcreateserial -out $2/$1.pem -days 365 -extfile $1.conf -extensions $4
     CHAIN_FILE="$2/$1.pem"
     if [[ $5 != 'no_chain' ]]
     then


### PR DESCRIPTION
## What was changed
Added an explicit -sha256 flag to openssl commands.

## Why?
To make sure sha256 is used for signing.

## Checklist

1. Closes
2. How was this tested:
Manually

3. Any docs updates needed?
No
