### PR TITLE
Improvements to tls-full sample

### DIFF
--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -2,21 +2,39 @@
 
 This sample demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within a Temporal cluster when using intermediate CAs and different certificate chains for cluster and clients.
 It also shows how different clients can be given different server certificates when connecting to the same cluster using different server names.
-The generated certificates are in 
+The generated certificates are in
   - PKCS1 format for server
   - PKCS8 and PKCS12 format for client
+
+The signing relationships between the certificates look like this:
+
+```
+              server-root-ca                                       client-root-ca
+                     |                                                    |
+                     |                                                    |
+          server-intermediate-ca                              /-----------+-----------\
+                     |                                        |                       |
+                     |                        client-intermediate-ca-accounting       |
+      /--------------+--------------\                         |                       |
+      |              |              |                         |       client-intermediate-ca-development
+cluster-internode    |              |                         |                       |
+                     |              |             client-accounting-namespace         |
+             cluster-accounting     |                                                 |
+                                    |                                   client-development-namespace
+                           cluster-development
+```
 
 ### Steps to run this sample
 
 1. Generate test certificates with `generate-certs.sh`. This will create server and client certificates in a `certs` subdirectory.
 
 ```bash
-bash generate-certs.sh
+./generate-certs.sh
 ```
 
 2. Start Temporal with `start-temporal.sh`. This will bring up a Temporal cluster (via `docker-compose`) with the `certs` subdirectory mounted as a volume and Temporal configured to use the test certificates in it to secure network communications.
 
 ```bash
-bash start-temporal.sh
+./start-temporal.sh
 ```
 

--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -38,3 +38,20 @@ cluster-internode    |              |                         |                 
 ./start-temporal.sh
 ```
 
+3. You can use docker to enter the cli containers and use `tctl` like this (in another terminal):
+
+```bash
+docker exec -it tls-full-temporal-cli-admin-1 bash
+docker exec -it tls-full-temporal-cli-development-1 bash
+docker exec -it tls-full-temporal-cli-accounting-1 bash
+```
+
+Environment variables are set up to provide the `development` and `accounting` containers with access to namespaces with the respective names.
+(You'll have to create them first with `tctl namespace register`.)
+
+4. But you might notice that all three containers actually have identical (full admin-level) permissions!
+That's because there's no ClaimMapper or Authorizer actually examining the client certs to determine permissions.
+To actually enforce namespace access, you'll have to build the server with a custom ClaimMapper, and turn on the default Authorizer also.
+You can look in [tlsClaimMapper.go](./tlsClaimMapper.go) for an example that will work with the certs in this sample,
+and in [the authorizer sample](../../extensibility/authorizer/) for more instructions on how to build a custom server.
+

--- a/tls/tls-full/config_template.yaml
+++ b/tls/tls-full/config_template.yaml
@@ -149,13 +149,6 @@ global:
                     requireClientAuth: true
                     clientCaFiles:
                         - /etc/temporal/config/certs/client/ca/client-intermediate-ca-development.pem
-        systemWorker:
-            certFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.pem
-            keyFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.key
-            client:
-                serverName: internode.cluster-x.contoso.com
-                rootCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
     {{- if .Env.STATSD_ENDPOINT }}
     metrics:
         statsd:
@@ -174,6 +167,12 @@ services:
         rpc:
             grpcPort: {{ $temporalGrpcPort }}
             membershipPort: {{ default .Env.FRONTEND_MEMBERSHIP_PORT "6933" }}
+            bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
+
+    internal-frontend:
+        rpc:
+            grpcPort: {{ default .Env.INTERNAL_FRONTEND_GRPC_PORT "7236" }}
+            membershipPort: {{ default .Env.INTERNAL_FRONTEND_MEMBERSHIP_PORT "6936" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
 
     matching:
@@ -251,11 +250,6 @@ kafka:
         visibility:
             topic: temporal-visibility-dev
             dlq-topic: temporal-visibility-dev-dlq
-
-{{ $publicIp := default .Env.BIND_ON_IP "127.0.0.1" -}}
-{{- $defaultPublicHostPost := (print $publicIp ":" $temporalGrpcPort) -}}
-publicClient:
-    hostPort: {{ default .Env.PUBLIC_FRONTEND_ADDRESS $defaultPublicHostPost }}
 
 dynamicConfigClient:
     filepath: {{ default .Env.DYNAMIC_CONFIG_FILE_PATH "/etc/temporal/config/dynamicconfig" }}

--- a/tls/tls-full/config_template.yaml
+++ b/tls/tls-full/config_template.yaml
@@ -121,34 +121,34 @@ global:
         internode:
             server:
                 requireClientAuth: true
-                certFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.pem
-                keyFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.key
+                certFile: /certs/cluster/internode/cluster-internode.pem
+                keyFile: /certs/cluster/internode/cluster-internode.key
                 clientCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
+                    - /certs/cluster/ca/server-intermediate-ca.pem
             client:
                 serverName: internode.cluster-x.contoso.com
                 rootCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
+                    - /certs/cluster/ca/server-intermediate-ca.pem
         frontend:
             server:
                 requireClientAuth: true
-                certFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.pem
-                keyFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.key
+                certFile: /certs/cluster/internode/cluster-internode.pem
+                keyFile: /certs/cluster/internode/cluster-internode.key
                 clientCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
+                    - /certs/cluster/ca/server-intermediate-ca.pem
             hostOverrides:
                 accounting.cluster-x.contoso.com:
-                    certFile: /etc/temporal/config/certs/cluster/accounting/cluster-accounting-chain.pem
-                    keyFile: /etc/temporal/config/certs/cluster/accounting/cluster-accounting.key
+                    certFile: /certs/cluster/accounting/cluster-accounting-chain.pem
+                    keyFile: /certs/cluster/accounting/cluster-accounting.key
                     requireClientAuth: true
                     clientCaFiles:
-                        - /etc/temporal/config/certs/client/ca/client-intermediate-ca-accounting.pem
+                        - /certs/client/ca/client-intermediate-ca-accounting.pem
                 development.cluster-x.contoso.com:
-                    certFile: /etc/temporal/config/certs/cluster/development/cluster-development-chain.pem
-                    keyFile: /etc/temporal/config/certs/cluster/development/cluster-development.key
+                    certFile: /certs/cluster/development/cluster-development-chain.pem
+                    keyFile: /certs/cluster/development/cluster-development.key
                     requireClientAuth: true
                     clientCaFiles:
-                        - /etc/temporal/config/certs/client/ca/client-intermediate-ca-development.pem
+                        - /certs/client/ca/client-intermediate-ca-development.pem
     {{- if .Env.STATSD_ENDPOINT }}
     metrics:
         statsd:

--- a/tls/tls-full/docker-compose.yml
+++ b/tls/tls-full/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
       - ./config_template.yaml:/etc/temporal/config/config_template.yaml
     environment:
+      - "SERVICES=frontend:matching:history:worker:internal-frontend"
       - "CASSANDRA_SEEDS=cassandra"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
       - "SKIP_DEFAULT_NAMESPACE_CREATION=true"

--- a/tls/tls-full/docker-compose.yml
+++ b/tls/tls-full/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - "SERVICES=frontend:matching:history:worker:internal-frontend"
       - "CASSANDRA_SEEDS=cassandra"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
-      - "SKIP_DEFAULT_NAMESPACE_CREATION=true"
       - "TEMPORAL_CLI_ADDRESS=temporal:7233"
       - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
       - "TEMPORAL_CLI_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/cluster/internode/cluster-internode.pem"

--- a/tls/tls-full/docker-compose.yml
+++ b/tls/tls-full/docker-compose.yml
@@ -60,7 +60,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
+      - "${TEMPORAL_LOCAL_CERT_DIR}/client/accounting:${TEMPORAL_TLS_CERTS_DIR}/client/accounting"
+      - "${TEMPORAL_LOCAL_CERT_DIR}/cluster/ca/server-intermediate-ca.pem:${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
     environment:
       - "TEMPORAL_CLI_ADDRESS=temporal:7233"
       - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
@@ -68,6 +69,7 @@ services:
       - "TEMPORAL_CLI_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/client/accounting/client-accounting-namespace.key"
       - "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION=true"
       - "TEMPORAL_CLI_TLS_SERVER_NAME=accounting.cluster-x.contoso.com"
+      - "TEMPORAL_CLI_NAMESPACE=accounting"
     depends_on:
       - temporal
   temporal-cli-development:
@@ -75,7 +77,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
+      - "${TEMPORAL_LOCAL_CERT_DIR}/client/development:${TEMPORAL_TLS_CERTS_DIR}/client/development"
+      - "${TEMPORAL_LOCAL_CERT_DIR}/cluster/ca/server-intermediate-ca.pem:${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
     environment:
       - "TEMPORAL_CLI_ADDRESS=temporal:7233"
       - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
@@ -83,5 +86,6 @@ services:
       - "TEMPORAL_CLI_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/client/development/client-development-namespace.key"
       - "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION=true"
       - "TEMPORAL_CLI_TLS_SERVER_NAME=development.cluster-x.contoso.com"
+      - "TEMPORAL_CLI_NAMESPACE=development"
     depends_on:
       - temporal

--- a/tls/tls-full/start-temporal.sh
+++ b/tls/tls-full/start-temporal.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # TEMPORAL_TLS_CERTS_DIR is used in docker-compose.yml to point 
 # to the location of generated test certificates within the container
 export TEMPORAL_TLS_CERTS_DIR=/etc/temporal/config/certs

--- a/tls/tls-full/start-temporal.sh
+++ b/tls/tls-full/start-temporal.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# TEMPORAL_TLS_CERTS_DIR is used in docker-compose.yml to point 
+# TEMPORAL_TLS_CERTS_DIR is used in docker-compose.yml to point
 # to the location of generated test certificates within the container
-export TEMPORAL_TLS_CERTS_DIR=/etc/temporal/config/certs
+export TEMPORAL_TLS_CERTS_DIR=/certs
 
 # TEMPORAL_LOCAL_CERT_DIR is used in docker-compose.yml to point
 # to our local directory with generated certificates to be mounted

--- a/tls/tls-full/tlsClaimMapper.go
+++ b/tls/tls-full/tlsClaimMapper.go
@@ -1,0 +1,51 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sample_tls_claim_mapper
+
+import "strings"
+
+const (
+	adminCN      = "internode.cluster-x.contoso.com"
+	clientDomain = "client.contoso.com"
+)
+
+type tlsClaimMapper struct{}
+
+func NewTLSClaimMapper() ClaimMapper {
+	return &tlsClaimMapper{}
+}
+
+func (a *tlsClaimMapper) GetClaims(authInfo *AuthInfo) (*Claims, error) {
+	claims := Claims{}
+	if authInfo.TLSSubject != nil {
+		cn := authInfo.TLSSubject.CommonName
+		if cn == adminCN {
+			claims.System = RoleAdmin
+		} else if ns, domain, ok := strings.Cut(cn, "."); ok && domain == clientDomain {
+			claims.Namespaces = map[string]Role{ns: RoleWriter}
+		}
+	}
+	return &claims, nil
+}


### PR DESCRIPTION
## What was changed
Various improvements to tls-full:
- add diagram of certs
- add notes about ClaimMapper and example that works with this sample
- switched to use internal-frontend to simplify config
- removed systemWorker section and publicClient section
- expose only needed certs+keys to example cli containers
- clean up generate-certs.sh script

## Why?
Make sample easier to understand and extend

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
lots and lots of manual testing (including the example ClaimMapper, although it can't be packaged up nicely due to the sample using docker images)

3. Any docs updates needed?
yes