### PR TITLE
added information about using TLS (as opposed to mTLS), with examples…

### DIFF
--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -19,3 +19,70 @@ bash generate-test-certs.sh
 bash start-temporal.sh
 ```
 
+## Disabling Client Authentication
+The Temporal Cluster you launched by running the commands above uses mutual TLS (mTLS), meaning that it requires the client and server to authenticate one another by verifying each other's certificates when making a connection. If you would prefer to use TLS (that is, disable the server's veriification of the client's certificate), edit the `docker-compose.yml` file, change the value of `TEMPORAL_TLS_REQUIRE_CLIENT_AUTH` variable from `true` to `false`, and then restart the `start-temporal.sh` script.
+
+# Connecting to the Cluster via TLS (Command Line)
+After disabling client authentication as per the above directions, you could use the `temporal` command to connect to the cluster by specifying options for the path to the CA certificate and the TLS Server Name. The following example shows how to use these options to register a new namespace (`testing`, in this example):
+
+```bash
+temporal operator namespace create \
+    --tls-ca-path certs/ca.cert \
+	--tls-server-name tls-sample \
+	testing
+```
+
+Here is the corresponding `tctl` command:
+```bash
+tctl \
+    --tls_ca_path certs/ca.cert \
+	--tls_server_name tls-sample \
+	--namespace testing \
+	namespace register
+```
+
+# Connecting to the Cluster via TLS (Go SDK)
+
+The following example shows how to use the Go SDK to create a 
+Temporal that can connect to this Temporal Cluster using TLS:
+
+```go
+import (
+	"go.temporal.io/sdk/client"
+	"crypto/tls"
+	"crypto/x509"
+	"log"
+	"os"
+)
+
+
+func createClient() {
+	// load the server's certificate 
+	serverPEM, err := os.ReadFile("certs/cluster.pem")
+	if err != nil {
+		log.Fatalln("failed to load server certificate")
+	}
+
+	// add it to a set of certificate authorities
+	serverCAPool := x509.NewCertPool()
+	if !serverCAPool.AppendCertsFromPEM(serverPEM) {
+		log.Fatalln("invalid server cert PEM")
+	}
+
+	// configure the TLS connection
+	c, err := client.Dial(client.Options{
+		ConnectionOptions: client.ConnectionOptions{
+			TLS: &tls.Config{
+				RootCAs:      serverCAPool,
+				ServerName:   "tls-sample",
+			},
+		},
+	})
+
+	if err != nil {
+		log.Fatalln("unable to create client", err)
+	}
+	defer c.Close()
+
+	// Code that uses the Client would follow
+```

--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -1,11 +1,11 @@
-### TLS
+# TLS
 
 This samples demonstrates how to configure Transport Layer Security (TLS) to secure network communication with and within Temporal cluster.
 The generated certificates are in 
   - PKCS1 format for server
   - PKCS8 and PKCS12 format for client
 
-### Steps to run this sample
+## Steps to run this sample
 
 1. Generate test certificates with `generate-test-certs.sh`. This will create server and client certificates in the `certs` subdirectory.
 
@@ -19,10 +19,10 @@ bash generate-test-certs.sh
 bash start-temporal.sh
 ```
 
-## Disabling Client Authentication
+### Disabling Client Authentication
 The Temporal Cluster you launched by running the commands above uses mutual TLS (mTLS), meaning that it requires the client and server to authenticate one another by verifying each other's certificates when making a connection. If you would prefer to use TLS (that is, disable the server's veriification of the client's certificate), edit the `docker-compose.yml` file, change the value of `TEMPORAL_TLS_REQUIRE_CLIENT_AUTH` variable from `true` to `false`, and then restart the `start-temporal.sh` script.
 
-# Connecting to the Cluster via TLS (Command Line)
+#### Connecting to the Cluster via TLS (Command Line)
 After disabling client authentication as per the above directions, you could use the `temporal` command to connect to the cluster by specifying options for the path to the CA certificate and the TLS Server Name. The following example shows how to use these options to register a new namespace (`testing`, in this example):
 
 ```bash
@@ -41,7 +41,7 @@ tctl \
 	namespace register
 ```
 
-# Connecting to the Cluster via TLS (Go SDK)
+#### Connecting to the Cluster via TLS (Go SDK)
 
 The following example shows how to use the Go SDK to create a 
 Temporal that can connect to this Temporal Cluster using TLS:

--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -28,17 +28,17 @@ After disabling client authentication as per the above directions, you could use
 ```bash
 temporal operator namespace create \
     --tls-ca-path certs/ca.cert \
-	--tls-server-name tls-sample \
-	testing
+    --tls-server-name tls-sample \
+    testing
 ```
 
 Here is the corresponding `tctl` command:
 ```bash
 tctl \
     --tls_ca_path certs/ca.cert \
-	--tls_server_name tls-sample \
-	--namespace testing \
-	namespace register
+    --tls_server_name tls-sample \
+    --namespace testing \
+    namespace register
 ```
 
 #### Connecting to the Cluster via TLS (Go SDK)


### PR DESCRIPTION
## What was changed
I updated the README to describe how to disable client authentication and to provide examples of how to subsequently connect to the cluster using the command line as well as the Go SDK. 

## Why?
The Temporal documentation explains how to connect to a cluster that does not use TLS at all. It also explains how to connect to a cluster that uses mTLS. However, it does not explain how to connect to a cluster that uses TLS (i.e., without client certificates), which I believe represents a common configuration for self-hosted clusters. By following this README, it is now possible for someone to quickly set up and run such a cluster for testing purposes and also be able to access it from the command line or code (Go SDK). 

While it would be a nice future enhancement to add code examples for other SDKs, they are likely similar enough in concept to the Go example that a developer could create one of their own in the meantime.

## Checklist

1. Closes: N/A

2. How was this tested:
Chad Retz from the Temporal SDK team helped me come up with working examples for `tctl` and Go. I simplified those a bit and then adapted the `tctl` example for the new `temporal` command. I tested all of these locally.

3. Any docs updates needed?
I will file this separately, but the [Foundations section of the Developer guide](https://docs.temporal.io/application-development/foundations#connect-to-a-dev-cluster) should be updated to include this example (in addition to the no TLS and mTLS examples already present). 

The documentation for `tctl` and `temporal` (CLI) are focused primarily on individual options, rather than scenarios involving combinations of those options that lead to a specific outcome, so no update is feasbile to those in their current form.
