### PR TITLE
fix(metric type): Use rate instead of count when submitting metric to Datadog

### DIFF
--- a/cloud/observability/promql-to-dd-go/worker/utils.go
+++ b/cloud/observability/promql-to-dd-go/worker/utils.go
@@ -32,9 +32,9 @@ func PromHistogramToDatadogGauge(name string, quantile float64, matrix model.Mat
 	return matrixToSeries(name, metricType, matrix)
 }
 
-func PromCountToDatadogCount(name string, matrix model.Matrix) []datadogV2.MetricSeries {
+func PromCountToDatadogRate(name string, matrix model.Matrix) []datadogV2.MetricSeries {
 	name = strings.TrimSuffix(name, "_count") + "_rate1m"
-	metricType := datadogV2.METRICINTAKETYPE_COUNT
+	metricType := datadogV2.METRICINTAKETYPE_RATE
 	return matrixToSeries(name, metricType, matrix)
 }
 

--- a/cloud/observability/promql-to-dd-go/worker/utils_test.go
+++ b/cloud/observability/promql-to-dd-go/worker/utils_test.go
@@ -14,7 +14,7 @@ func Ptr[T any](v T) *T {
 	return &v
 }
 
-func TestPromMatrixToDatadogSeries(t *testing.T) {
+func TestPromHistogramToDatadogGauge(t *testing.T) {
 	testCases := []struct {
 		name       string
 		metricName string

--- a/cloud/observability/promql-to-dd-go/worker/worker.go
+++ b/cloud/observability/promql-to-dd-go/worker/worker.go
@@ -79,8 +79,8 @@ func (w *Worker) do(errorChan chan<- error) {
 	}
 	log.Printf("Received %d histogram series\n", len(histogramSeries))
 
-	// counters
-	counterSeries := []datadogV2.MetricSeries{}
+	// rates
+	rateSeries := []datadogV2.MetricSeries{}
 	for _, counterName := range counters {
 		promql := fmt.Sprintf(RatePromQL, counterName)
 		matrix, err := w.QueryMetrics(promql, queryRange)
@@ -88,12 +88,12 @@ func (w *Worker) do(errorChan chan<- error) {
 			errorChan <- err
 			return
 		}
-		counterSeries = append(counterSeries, PromCountToDatadogCount(counterName, matrix)...)
+		rateSeries = append(rateSeries, PromCountToDatadogRate(counterName, matrix)...)
 	}
-	log.Printf("Received %d counter series\n", len(counterSeries))
+	log.Printf("Received %d rate series\n", len(rateSeries))
 
 	log.Printf("Submitting to Datadog\n")
-	series := append(histogramSeries, counterSeries...)
+	series := append(histogramSeries, rateSeries...)
 	err = w.SubmitMetrics(series)
 	if err != nil {
 		errorChan <- err


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR fixes the previously mistakenly chosen metric type when submitting to Datadog. Rate should be used instead of counter.

### Before
<img width="432" alt="image" src="https://github.com/temporalio/samples-server/assets/7697484/4c8ddbec-9042-4649-a77e-df4512f702ff">

### After
<img width="447" alt="image" src="https://github.com/temporalio/samples-server/assets/7697484/d897c54a-e0d9-48d4-bc25-15733c29dd1d">

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
