### PR TITLE
Use ENTRYPOINT instead of CMD to run promqltodd

### DIFF
--- a/cloud/observability/promql-to-dd-go/Dockerfile
+++ b/cloud/observability/promql-to-dd-go/Dockerfile
@@ -21,4 +21,4 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} centos:latest
 
 COPY --from=builder ${GOPATH:-/go}/bin/promqltodd /
 
-CMD ["/promqltodd"]
+ENTRYPOINT ["/promqltodd"]

--- a/cloud/observability/promql-to-dd-go/helm-charts/templates/deployment.yaml
+++ b/cloud/observability/promql-to-dd-go/helm-charts/templates/deployment.yaml
@@ -25,7 +25,6 @@ spec:
       - name: promqltodd
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
-        command: ["/promqltodd"]
         args:
         - --client-cert=/var/run/secrets/ca_cert
         - --client-key=/var/run/secrets/ca_key


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Use `ENTRYPOINT` to replace `CMD` in promql-to-dd-go Dockerfile.

## Why?

Requested at: https://github.com/temporalio/samples-server/issues/60

This is to add convenience to run the image as a binary by supplying flags directly without specifying the executable.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/samples-server/issues/60
2. How was this tested: Manually..