### PR TITLE
fix: support DD_SITE env var

### DIFF
--- a/cloud/observability/promql-to-dd-go/datadog/client.go
+++ b/cloud/observability/promql-to-dd-go/datadog/client.go
@@ -47,6 +47,16 @@ func (c *APIClient) SubmitMetrics(series []datadogV2.MetricSeries) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			ctx = datadog.NewDefaultContext(ctx)
+
+			// https://pkg.go.dev/github.com/DataDog/datadog-api-client-go/v2#hdr-Changing_Server
+			if site, ok := os.LookupEnv("DD_SITE"); ok {
+        			ctx = context.WithValue(
+            				ctx,
+        				datadog.ContextServerVariables,
+					map[string]string{"site": site},
+        			)
+    			}
+			
 			body := datadogV2.MetricPayload{Series: pagedSeries}
 
 			resp, httpr, err := c.api.SubmitMetrics(ctx, body, *datadogV2.NewSubmitMetricsOptionalParameters())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added support for the `DD_SITE` environmental variable.

## Why?
Not all users are part of the default datadog site. 
https://docs.datadoghq.com/getting_started/site/

1. Closes https://github.com/temporalio/samples-server/issues/69

2. How was this tested:
- [ ] Building and deploying on our own infrastructure
- [ ] WIll add a unit test to ensure the value is set on the context.

3. Any docs updates needed?
- [ ] update the readme to include details about the DD_SITE config option and add it to the helm chart.