### PR TITLE
Add query-interval-seconds Helm Chart Override

### DIFF
--- a/cloud/observability/promql-to-dd-go/helm-charts/templates/deployment.yaml
+++ b/cloud/observability/promql-to-dd-go/helm-charts/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - --client-cert=/var/run/secrets/ca_cert
         - --client-key=/var/run/secrets/ca_key
         - --prom-endpoint={{ .Values.prom_endpoint }}
+        - --query-interval-seconds={{ .Values.query_interval_seconds }}
         env:
         - name: DD_API_KEY
           valueFrom:


### PR DESCRIPTION
## What was changed
I've added the ability to override the default `600` seconds in the helm values file.

## Why?
600 seconds is too infrequent a scrape in some cases.

1. Closes
n/a

2. How was this tested:
Tiny change. No testing.

3. Any docs updates needed?
n/a
