### PR TITLE
bugfix: Release read lock instead of read-write lock

### DIFF
--- a/cloud/observability/promql-to-scrape/internal/server.go
+++ b/cloud/observability/promql-to-scrape/internal/server.go
@@ -44,7 +44,7 @@ func NewPromToScrapeServer(client *APIClient, conf *Config, addr string) *PromTo
 // metricsHandler is the HTTP handler for the "/metrics" endpoint.
 func (s *PromToScrapeServer) metricsHandler(w http.ResponseWriter, r *http.Request) {
 	s.RLock()
-	defer s.Unlock()
+	defer s.RUnlock()
 	if time.Since(s.lastSuccessfulTime) < 5*time.Minute {
 		fmt.Fprint(w, s.data)
 	} else {


### PR DESCRIPTION
The previous line acquires a read lock, we should release only the read lock.
