### PR TITLE
(promql-to-dd-go) add new flag to control sleep duration between runs

### DIFF
--- a/cloud/observability/promql-to-dd-go/cmd/promqltodd/main.go
+++ b/cloud/observability/promql-to-dd-go/cmd/promqltodd/main.go
@@ -22,6 +22,7 @@ func main() {
 	matrixPrefix := set.String("matrix-prefix", "temporal_cloud_", "Prefix of the metrics to be queried and send to Datadog")
 	stepDuration := set.Int("step-duration-seconds", 60, "The step between metrics")
 	queryInterval := set.Int("query-interval-seconds", 600, "Interval between each Prometheus query")
+	sleepDuration := set.Int("sleep-duration-seconds", 60, "Sleep duration between each data submission")
 
 	if err := set.Parse(os.Args[1:]); err != nil {
 		log.Fatalf("failed parsing args: %s", err)
@@ -51,6 +52,7 @@ func main() {
 		MetricPrefix:  *matrixPrefix,
 		StepDuration:  time.Duration(*stepDuration) * time.Second,
 		QueryInterval: time.Duration(*queryInterval) * time.Second,
+		SleepDuration: time.Duration(*sleepDuration) * time.Second,
 		Quantiles:     []float64{0.5, 0.9, 0.95, 0.99},
 	}
 

--- a/cloud/observability/promql-to-dd-go/worker/worker.go
+++ b/cloud/observability/promql-to-dd-go/worker/worker.go
@@ -19,6 +19,7 @@ type Worker struct {
 	Quantiles     []float64
 	QueryInterval time.Duration
 	StepDuration  time.Duration
+	SleepDuration time.Duration
 }
 
 const (
@@ -29,7 +30,7 @@ const (
 
 func (w *Worker) Run() {
 	interrupt := interruptCh()
-	ticker := time.NewTicker(w.QueryInterval)
+	ticker := time.NewTicker(w.SleepDuration)
 	defer ticker.Stop()
 	errs := make(chan error, 1)
 
@@ -100,7 +101,7 @@ func (w *Worker) do(errorChan chan<- error) {
 		return
 	}
 	log.Printf("Submitted total of %d series\n", len(series))
-	log.Printf("Awaits next tick (interval: %.0f seconds)\n", w.QueryInterval.Seconds())
+	log.Printf("Awaits next tick (interval: %.0f seconds)\n", w.SleepDuration.Seconds())
 }
 
 func (w *Worker) calcRange() promapi.Range {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Previous, the sleep duration between each data pull/push and the query window was using the same setting/flag.

This PR introduces a new flag to control sleep duration separately and default to 60s. This is also aligned with the Python implementation: https://github.com/temporalio/samples-server/blob/78fbef030e15a022e409fdb6c1e0032940e32f97/cloud/observability/promql-to-dd.py#L62

Output (new default 60 seconds interval):
```
2024/01/22 20:03:37 Submitted total of 2100 series
2024/01/22 20:03:37 Awaits next tick (interval: 60 seconds)
2024/01/22 20:03:48 Querying Prometheus
2024/01/22 20:03:48 Found 1 histogram metrics: [temporal_cloud_v0_service_latency_bucket]
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Manual (see above)

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
