### PR TITLE
Add GHA for building promql-to-scrape

### DIFF
--- a/.github/workflows/promql-to-scrape.yaml
+++ b/.github/workflows/promql-to-scrape.yaml
@@ -1,0 +1,59 @@
+name: Test, build and publish promql-to-scrape
+
+on:
+  push:
+    paths:
+      - 'cloud/observability/promql-to-scrape/**'
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    paths:
+      - 'cloud/observability/promql-to-scrape/**'
+
+env:
+  IMAGE_NAME: promql-to-scrape
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to registry
+        # This is where you will update the personal access token to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Setup Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          context: cloud/observability/promql-to-scrape
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true

--- a/cloud/observability/promql-to-scrape/Dockerfile
+++ b/cloud/observability/promql-to-scrape/Dockerfile
@@ -1,11 +1,24 @@
-FROM golang:1.21-alpine
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.21 as builder
 
-WORKDIR /usr/src/app
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
-COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+ARG Version
+ARG GitCommit
+
+WORKDIR ${GOPATH:-/go}/src/promql-to-scrape
 
 COPY . .
-RUN go build -v -o /usr/local/bin/promql-to-scrape ./cmd/promql-to-scrape/main.go
+RUN go mod download
+RUN go get -d -v ./...
 
-ENTRYPOINT ["/usr/local/bin/promql-to-scrape"]
+RUN CGO_ENABLED=${CGO_ENABLED:-0} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+  go build -o ${GOPATH:-/go}/bin/ ${GOPATH:-/go}/src/promql-to-scrape/cmd/promql-to-scrape
+
+FROM --platform=${BUILDPLATFORM:-linux/amd64} centos:latest
+
+COPY --from=builder ${GOPATH:-/go}/bin/promql-to-scrape /
+
+ENTRYPOINT ["/promql-to-scrape"]


### PR DESCRIPTION
## What was changed

Adding GHA workflow to build https://github.com/temporalio/samples-server/tree/main/cloud/observability/promql-to-scrape and publish to https://github.com/orgs/temporalio/packages

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
