### PR TITLE
Add DD_SITE env var

### DIFF
--- a/cloud/observability/promql-to-dd-go/helm-charts/templates/deployment.yaml
+++ b/cloud/observability/promql-to-dd-go/helm-charts/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
             secretKeyRef:
               name: {{ template "promql-to-dd-go.name" . }}-secrets
               key: dd_api_key
+        - name: DD_SITE
+          value: {{ .Values.dd_site }}
         volumeMounts:
         - name: secrets
           mountPath: /var/run/secrets


### PR DESCRIPTION
Add missing DD_SITE env var to the promql-to-dd-go Helm template
