### PR TITLE
FIX(promql-to-scrape, promql-to-dd-go): Proxy configuration from environment variables

### DIFF
--- a/cloud/observability/promql-to-dd-go/prometheus/client.go
+++ b/cloud/observability/promql-to-dd-go/prometheus/client.go
@@ -45,7 +45,7 @@ func NewAPIClient(cfg Config) (*APIClient, error) {
 	}
 
 	httpClient := &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		Transport: &http.Transport{TLSClientConfig: tlsCfg, Proxy: http.ProxyFromEnvironment},
 	}
 
 	client, err := NewHttpClient(cfg.TargetHost, httpClient)

--- a/cloud/observability/promql-to-scrape/internal/client.go
+++ b/cloud/observability/promql-to-scrape/internal/client.go
@@ -45,7 +45,7 @@ func NewAPIClient(cfg APIConfig) (*APIClient, error) {
 	}
 
 	httpClient := &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		Transport: &http.Transport{TLSClientConfig: tlsCfg, Proxy: http.ProxyFromEnvironment},
 	}
 
 	client, err := NewHttpClient(cfg.TargetHost, httpClient)


### PR DESCRIPTION
Changed client.go files to make API calls respect Proxy configuration from environment variables.

## What was changed
Changed http client to initialize with environment variable proxies.

## Why?
When using the sample server it wouldn't send API calls through our corporate proxy and API calls to temporal cloud would fail.

## How was this tested:
Tested by monitoring logs and observed working /metrics endpoint.