### PR TITLE
update tls-simple, tls-full, and extensibility authorizer to use ES visibility and temporal cli

### DIFF
--- a/extensibility/authorizer/README.md
+++ b/extensibility/authorizer/README.md
@@ -6,13 +6,13 @@ The sample implementation of the authorizer interface `authorization.Authorizer`
 ### Steps to run this sample
 1. Start up the dependencies by running the `make start-dependencies` command from within the main Temporal repository as described in the [contribution guide](https://github.com/temporalio/temporal/blob/master/CONTRIBUTING.md#run-temporal-server-locally).
 
-2. Create the database schema by running `make install-schema`.
+2. Create the database schema by running `make install-schema-cass-es`.
 
 3. Start Temporal by running `go run authorizer/server/main.go`.
 
-4. Use `tctl` to interact with Temporal
+4. Use `temporal` cli to interact with Temporal
 
-- Run `tctl n l` to list available namespaces. You should only see "temporal-system" initially.
-- Run `tctl --ns test n register` to create a namespace "test"
-- Run `tctl n l` to see "test" listed
-- Run `tctl --ns test n update` to try to update the "test" namespace. You should see a `PermissionDenied` error because `myAuthorizer` denies `UpdateNamespace` calls.
+- Run `temporal operator namespace list` to list available namespaces. You should only see "temporal-system" initially.
+- Run `temporal operator namespace create -n test` to create a namespace "test"
+- Run `temporal operator namespace list` to see "test" listed
+- Run `temporal operator namespace update -n test` to try to update the "test" namespace. You should see a `PermissionDenied` error because `myAuthorizer` denies `UpdateNamespace` calls.

--- a/extensibility/authorizer/myAuthorizer.go
+++ b/extensibility/authorizer/myAuthorizer.go
@@ -24,6 +24,7 @@ package authorizer
 
 import (
 	"context"
+	"strings"
 
 	"go.temporal.io/server/common/authorization"
 )
@@ -48,20 +49,20 @@ func (a *myAuthorizer) Authorize(_ context.Context, claims *authorization.Claims
 		return decisionAllow, nil
 	}
 
-	// Allow all calls except UpdateNamespace through when claim mapper isn't invoked
-	// Claim mapper is skipped unless TLS is configured or an auth token is passed
-	if claims == nil && target.APIName != "UpdateNamespace" {
+	// Allow all operations for system-level admins and writers
+	if claims != nil && claims.System&(authorization.RoleAdmin|authorization.RoleWriter) != 0 {
 		return decisionAllow, nil
 	}
 
-	// Allow all operations for system-level admins and writers
-	if claims.System & (authorization.RoleAdmin | authorization.RoleWriter) != 0 {
+	// Allow all calls except UpdateNamespace through when claim mapper isn't invoked
+	// Claim mapper is skipped unless TLS is configured or an auth token is passed
+	if claims == nil && !strings.Contains(target.APIName, "UpdateNamespace") {
 		return decisionAllow, nil
 	}
 
 	// For other namespaces, deny "UpdateNamespace" API unless the caller has a writer role in it
-	if target.APIName == "UpdateNamespace" {
-		if claims.Namespaces[target.Namespace] & authorization.RoleWriter != 0 {
+	if strings.Contains(target.APIName, "UpdateNamespace") {
+		if claims != nil && claims.Namespaces[target.Namespace]&authorization.RoleWriter != 0 {
 			return decisionAllow, nil
 		} else {
 			return decisionDeny, nil

--- a/extensibility/config/development.yaml
+++ b/extensibility/config/development.yaml
@@ -1,16 +1,23 @@
 persistence:
   defaultStore: cass-default
-  visibilityStore: cass-visibility
+  visibilityStore: es-visibility
   numHistoryShards: 4
   datastores:
     cass-default:
       cassandra:
         hosts: "127.0.0.1"
         keyspace: "temporal"
-    cass-visibility:
-      cassandra:
-        hosts: "127.0.0.1"
-        keyspace: "temporal_visibility"
+    es-visibility:
+      elasticsearch:
+        version: "v7"
+        logLevel: "error"
+        url:
+          scheme: "http"
+          host: "127.0.0.1:9200"
+        indices:
+          visibility: temporal_visibility_v1_dev
+          # secondary_visibility: temporal_visibility_v1_secondary
+        closeIdleConnectionsInterval: 15s
 global:
   membership:
     maxJoinDuration: 30s
@@ -101,19 +108,6 @@ namespaceDefaults:
     visibility:
       state: "disabled"
       URI: "file:///tmp/temporal_vis_archival/development"
-
-kafka:
-  tls:
-    enabled: false
-  clusters:
-    test:
-      brokers:
-        - 127.0.0.1:9092
-  topics:
-    temporal-visibility-dev:
-      cluster: test
-    temporal-visibility-dev-dlq:
-      cluster: test
 
 publicClient:
   hostPort: "localhost:7233"

--- a/tls/tls-simple/README.md
+++ b/tls/tls-simple/README.md
@@ -28,17 +28,10 @@ After disabling client authentication as per the above directions, you could use
 ```bash
 temporal operator namespace create \
     --tls-ca-path certs/ca.cert \
+	--tls-cert-path certs/client.pem \
+	--tls-key-path certs/client.key \
     --tls-server-name tls-sample \
-    testing
-```
-
-Here is the corresponding `tctl` command:
-```bash
-tctl \
-    --tls_ca_path certs/ca.cert \
-    --tls_server_name tls-sample \
-    --namespace testing \
-    namespace register
+    -n testing
 ```
 
 #### Connecting to the Cluster via TLS (Go SDK)

--- a/tls/tls-simple/docker-compose.yml
+++ b/tls/tls-simple/docker-compose.yml
@@ -5,6 +5,18 @@ services:
     image: cassandra:3.11
     ports:
       - "9042:9042"
+  elasticsearch:
+    image: elasticsearch:7.10.1
+    ports:
+      - "9200:9200"
+    environment:
+      - "cluster.routing.allocation.disk.threshold_enabled=true"
+      - "cluster.routing.allocation.disk.watermark.low=512mb"
+      - "cluster.routing.allocation.disk.watermark.high=256mb"
+      - "cluster.routing.allocation.disk.watermark.flood_stage=128mb"
+      - "discovery.type=single-node"
+      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
+      - "xpack.security.enabled=false"
   temporal:
     image: temporalio/auto-setup:${SERVER_TAG:-latest}
     ports:
@@ -13,28 +25,25 @@ services:
       - ${DYNAMIC_CONFIG_DIR:-../config/dynamicconfig}:/etc/temporal/config/dynamicconfig
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
     environment:
-      - "CASSANDRA_SEEDS=cassandra"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+      - "CASSANDRA_SEEDS=cassandra"
+      - "ENABLE_ES=true"
+      - "ES_SEEDS=elasticsearch"
       - "SKIP_DEFAULT_NAMESPACE_CREATION=true"
+      - "SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES=true"
       - "TEMPORAL_TLS_SERVER_CA_CERT=${TEMPORAL_TLS_CERTS_DIR}/ca.cert"
       - "TEMPORAL_TLS_SERVER_CERT=${TEMPORAL_TLS_CERTS_DIR}/cluster.pem"
       - "TEMPORAL_TLS_SERVER_KEY=${TEMPORAL_TLS_CERTS_DIR}/cluster.key"
       - "TEMPORAL_TLS_REQUIRE_CLIENT_AUTH=true"
-      - "TEMPORAL_TLS_FRONTEND_CERT=${TEMPORAL_TLS_CERTS_DIR}/cluster.pem"
-      - "TEMPORAL_TLS_FRONTEND_KEY=${TEMPORAL_TLS_CERTS_DIR}/cluster.key"
       - "TEMPORAL_TLS_CLIENT1_CA_CERT=${TEMPORAL_TLS_CERTS_DIR}/ca.cert"
       - "TEMPORAL_TLS_CLIENT2_CA_CERT=${TEMPORAL_TLS_CERTS_DIR}/ca.cert"
-      - "TEMPORAL_TLS_INTERNODE_SERVER_NAME=tls-sample"
+      - "TEMPORAL_TLS_FRONTEND_CERT=${TEMPORAL_TLS_CERTS_DIR}/cluster.pem"
+      - "TEMPORAL_TLS_FRONTEND_KEY=${TEMPORAL_TLS_CERTS_DIR}/cluster.key"
       - "TEMPORAL_TLS_FRONTEND_SERVER_NAME=tls-sample"
       - "TEMPORAL_TLS_FRONTEND_DISABLE_HOST_VERIFICATION=false"
+      - "TEMPORAL_TLS_INTERNODE_SERVER_NAME=tls-sample"
       - "TEMPORAL_TLS_INTERNODE_DISABLE_HOST_VERIFICATION=false"
-      - "TEMPORAL_CLI_ADDRESS=temporal:7233" # used by tctl. Will be deprecated
-      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/ca.cert"
-      - "TEMPORAL_CLI_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/cluster.pem"
-      - "TEMPORAL_CLI_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/cluster.key"
-      - "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION=true"
-      - "TEMPORAL_CLI_TLS_SERVER_NAME=tls-sample"
-      - "TEMPORAL_ADDRESS=temporal:7233" # used by Temporal CLI
+      - "TEMPORAL_ADDRESS=temporal:7233"
       - "TEMPORAL_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/ca.cert"
       - "TEMPORAL_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/cluster.pem"
       - "TEMPORAL_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/cluster.key"
@@ -42,6 +51,7 @@ services:
       - "TEMPORAL_TLS_SERVER_NAME=tls-sample"
     depends_on:
       - cassandra
+      - elasticsearch
   temporal-ui:
     image: temporalio/ui:${UI_TAG:-latest}
     ports:
@@ -64,13 +74,7 @@ services:
     volumes:
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
     environment:
-      - "TEMPORAL_CLI_ADDRESS=temporal:7233" # used by tctl. Will be deprecated
-      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/ca.cert"
-      - "TEMPORAL_CLI_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/client.pem"
-      - "TEMPORAL_CLI_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/client.key"
-      - "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION=true"
-      - "TEMPORAL_CLI_TLS_SERVER_NAME=tls-sample"
-      - "TEMPORAL_ADDRESS=temporal:7233" # used by Temporal CLI
+      - "TEMPORAL_ADDRESS=temporal:7233"
       - "TEMPORAL_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/ca.cert"
       - "TEMPORAL_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/client.pem"
       - "TEMPORAL_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/client.key"


### PR DESCRIPTION

## What was changed
Title says it all.

## Why?
So the samples work

## Checklist
<!--- add/delete as needed --->

1. Closes OSS-3851 and OSS-2635

2. How was this tested:
Ran the samples based on READMEs.

3. Any docs updates needed?
should be done in the READMEs already.
